### PR TITLE
Fix crwlr/crawler version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/css-selector": "^6.2",
         "symfony/browser-kit": "^6.2",
         "symfony/dom-crawler": "^6.2",
-        "crwlr/crawler": "dev-main"
+        "crwlr/crawler": "^1.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.5",

--- a/src/Client/HtmlClient.php
+++ b/src/Client/HtmlClient.php
@@ -30,14 +30,12 @@ class HtmlClient extends HttpCrawler implements CrawlerInterface
      */
     public function extract(CrawlerDTO|Data $dto): Collection
     {
-        $results = new Collection();
-
         $this->input($dto->base_url)
             ->addStep(Http::get())                              // Load the listing page
             ->addStep(Html::getLinks($dto->iterator))    // Get the links to the articles
             ->addStep(Http::get())                              // Load the article pages
             ->addStep(
-                Html::first('article')->extract($dto->fields)->addToResult()
+                Html::first('article')->extract($dto->fields)
             );
 
         return collect($this->run());

--- a/src/Client/JsonClient.php
+++ b/src/Client/JsonClient.php
@@ -4,7 +4,6 @@ namespace Cornatul\Crawler\Client;
 
 use Crwlr\Crawler\Exceptions\UnknownLoaderKeyException;
 use Crwlr\Crawler\HttpCrawler;
-use Crwlr\Crawler\Steps\Html;
 use Crwlr\Crawler\Steps\Json;
 use Crwlr\Crawler\Steps\Loading\Http;
 use Crwlr\Crawler\UserAgents\BotUserAgent;
@@ -36,7 +35,7 @@ class JsonClient extends HttpCrawler implements CrawlerInterface
         $this->inputs($dto->links)
             ->addStep(Http::get())
             ->addStep(
-                Json::each($dto->iterator, $dto->fields)->addToResult()
+                Json::each($dto->iterator, $dto->fields)
             );
 
         return collect($this->run());


### PR DESCRIPTION
Requiring dev-main of a composer package, will automatically bring major version updates with breaking changes. Change it to ^1.0 for now.

Also removed the calls to `addToResult()` on last steps, because:
* when the final crawling result equals the outputs of the last step, it isn't necessary. You only need to do this, when the result should be composed with data, originating from different steps in the chain.
* `addToResult()` is replaced with `keep()` in v2, so removing this will make it easier to upgrade.

Further removed an unused import and an unused variable.